### PR TITLE
BUGFIX: Add fallback to UriImageSourceHelper for SVG images

### DIFF
--- a/Classes/FusionObjects/AssetImageSourceImplementation.php
+++ b/Classes/FusionObjects/AssetImageSourceImplementation.php
@@ -2,12 +2,26 @@
 namespace Sitegeist\Kaleidoscope\FusionObjects;
 
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\ResourceManagement\ResourceManager;
 use Sitegeist\Kaleidoscope\EelHelpers\ImageSourceHelperInterface;
 use Sitegeist\Kaleidoscope\EelHelpers\AssetImageSourceHelper;
 use Neos\Fusion\FusionObjects\AbstractFusionObject;
 
 class AssetImageSourceImplementation extends AbstractImageSourceImplementation
 {
+    /**
+     * @Flow\Inject
+     * @var ResourceManager
+     */
+    protected $resourceManager;
+
+    /**
+     * @var array
+     */
+    protected $nonScalableMediaTypes = [
+        'image/svg+xml'
+    ];
+
     /**
      * @return mixed
      */
@@ -34,6 +48,11 @@ class AssetImageSourceImplementation extends AbstractImageSourceImplementation
         $asset = $this->getAsset();
         if (!$asset) {
             return null;
+        }
+
+        if (in_array($asset->getResource()->getMediaType(), $this->nonScalableMediaTypes)) {
+            $uri = $this->resourceManager->getPublicPersistentResourceUri($asset->getResource());
+            return new UriImageSourceHelper($uri);
         }
 
         $helper = new AssetImageSourceHelper($asset);

--- a/Classes/FusionObjects/AssetImageSourceImplementation.php
+++ b/Classes/FusionObjects/AssetImageSourceImplementation.php
@@ -5,7 +5,7 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\ResourceManagement\ResourceManager;
 use Sitegeist\Kaleidoscope\EelHelpers\ImageSourceHelperInterface;
 use Sitegeist\Kaleidoscope\EelHelpers\AssetImageSourceHelper;
-use Neos\Fusion\FusionObjects\AbstractFusionObject;
+use Sitegeist\Kaleidoscope\EelHelpers\UriImageSourceHelper;
 
 class AssetImageSourceImplementation extends AbstractImageSourceImplementation
 {

--- a/Classes/FusionObjects/DummyImageSourceImplementation.php
+++ b/Classes/FusionObjects/DummyImageSourceImplementation.php
@@ -4,7 +4,6 @@ namespace Sitegeist\Kaleidoscope\FusionObjects;
 use Neos\Flow\Annotations as Flow;
 use Sitegeist\Kaleidoscope\EelHelpers\ImageSourceHelperInterface;
 use Sitegeist\Kaleidoscope\EelHelpers\DummyImageSourceHelper;
-use Neos\Fusion\FusionObjects\AbstractFusionObject;
 
 class DummyImageSourceImplementation extends AbstractImageSourceImplementation
 {

--- a/Classes/FusionObjects/UriImageSourceImplementation.php
+++ b/Classes/FusionObjects/UriImageSourceImplementation.php
@@ -3,7 +3,6 @@ namespace Sitegeist\Kaleidoscope\FusionObjects;
 
 use Neos\Flow\Annotations as Flow;
 use Sitegeist\Kaleidoscope\EelHelpers\ImageSourceHelperInterface;
-use Sitegeist\Kaleidoscope\EelHelpers\ResourceImageSourceHelper;
 use Neos\Fusion\FusionObjects\AbstractFusionObject;
 use Sitegeist\Kaleidoscope\EelHelpers\UriImageSourceHelper;
 


### PR DESCRIPTION
The AssetImageSource will create an UriImageSourceHelper if an svg image was selected.