### PR TITLE
BUGFIX: __toString must not throw an exception

### DIFF
--- a/Classes/EelHelpers/AbstractImageSourceHelper.php
+++ b/Classes/EelHelpers/AbstractImageSourceHelper.php
@@ -118,7 +118,6 @@ abstract class AbstractImageSourceHelper implements ImageSourceHelperInterface
         }
     }
 
-
     /**
      * If the source is cast to string the default source is returned
      *
@@ -126,6 +125,10 @@ abstract class AbstractImageSourceHelper implements ImageSourceHelperInterface
      */
     public function __toString(): string
     {
-        return $this->src();
+        try {
+            return $this->src();
+        } catch (\Exception $e) {
+            return $e->getMessage();
+        }
     }
 }


### PR DESCRIPTION
When an image is not found due to security constraints, an exception is thrown
which is covered by PHPs exception that __toString should never throw an exception.