### PR TITLE
FEATURE: add `setDimensions` to imageSourceInterface and add second `preserveAspect` argument to `setWidth` and `setHeight`

### DIFF
--- a/Classes/EelHelpers/AbstractImageSourceHelper.php
+++ b/Classes/EelHelpers/AbstractImageSourceHelper.php
@@ -27,16 +27,39 @@ abstract class AbstractImageSourceHelper implements ImageSourceHelperInterface
      */
     protected $thumbnailPresets;
 
-    public function setWidth(int $targetWidth = null) : ImageSourceHelperInterface
+    /**
+     * @param int|null $targetWidth
+     * @param bool $preserveAspectRatio
+     * @return ImageSourceHelperInterface
+     */
+    public function setWidth(int $targetWidth = null, bool $preserveAspect = false) : ImageSourceHelperInterface
     {
         $newSource = clone($this);
         $newSource->targetWidth = $targetWidth;
         return $newSource;
     }
 
-    public function setHeight(int $targetHeight = null) : ImageSourceHelperInterface
+    /**
+     * @param int|null $targetHeight
+     * @param bool $preserverAspectRatio
+     * @return ImageSourceHelperInterface
+     */
+    public function setHeight(int $targetHeight = null, bool $preserveAspect = false) : ImageSourceHelperInterface
     {
         $newSource = clone($this);
+        $newSource->targetHeight = $targetHeight;
+        return $newSource;
+    }
+
+    /**
+     * @param int|null $targetWidth
+     * @param int|null $targetHeight
+     * @return ImageSourceHelperInterface
+     */
+    public function setDimensions(int $targetWidth = null, int $targetHeight = null) : ImageSourceHelperInterface
+    {
+        $newSource = clone($this);
+        $newSource->targetWidth = $targetWidth;
         $newSource->targetHeight = $targetHeight;
         return $newSource;
     }
@@ -111,7 +134,7 @@ abstract class AbstractImageSourceHelper implements ImageSourceHelperInterface
      */
     public function allowsCallOfMethod($methodName)
     {
-        if (in_array($methodName, ['setWidth', 'setHeight', 'applyPreset', 'src', 'srcset'])) {
+        if (in_array($methodName, ['setWidth', 'setHeight', 'setDimensions', 'applyPreset', 'src', 'srcset'])) {
             return true;
         } else {
             return false;

--- a/Classes/EelHelpers/AbstractScalableImageSourceHelper.php
+++ b/Classes/EelHelpers/AbstractScalableImageSourceHelper.php
@@ -1,0 +1,99 @@
+<?php
+namespace Sitegeist\Kaleidoscope\EelHelpers;
+
+
+abstract class AbstractScalableImageSourceHelper extends AbstractImageSourceHelper implements ScalableImageSourceHelperInterface
+{
+    /**
+     * @var int
+     */
+    protected $baseWidth = null;
+
+    /**
+     * @var int
+     */
+    protected $baseHeight = null;
+
+    /**
+     * @param int|null $targetWidth
+     * @param bool $preserveAspectRatio
+     * @return ImageSourceHelperInterface
+     */
+    public function setWidth(int $targetWidth = null, bool $preserveAspect = false) : ImageSourceHelperInterface
+    {
+        $newSource = clone($this);
+        $newSource->targetWidth = $targetWidth;
+        if ($preserveAspect === true) {
+            $aspect = ($this->targetWidth ?: $this->baseWidth) / ($this->targetHeight ?: $this->baseHeight);
+            $newSource->targetHeight = round($targetWidth / $aspect);
+        }
+        return $newSource;
+    }
+
+    /**
+     * @param int|null $targetHeight
+     * @param bool $preserverAspectRatio
+     * @return ImageSourceHelperInterface
+     */
+    public function setHeight(int $targetHeight = null, bool $preserveAspect = false) : ImageSourceHelperInterface
+    {
+        $newSource = clone($this);
+        $newSource->targetHeight = $targetHeight;
+        if ($preserveAspect === true) {
+            $aspect = ($this->targetWidth ?: $this->baseWidth) / ($this->targetHeight ?: $this->baseHeight);
+            $newSource->targetWidth = round($targetHeight * $aspect);
+        }
+        return $newSource;
+    }
+
+    /**
+     * @param float $factor
+     * @return ImageSourceHelperInterface
+     */
+    public function scale(float $factor): ImageSourceHelperInterface
+    {
+        $scaledHelper = clone($this);
+
+        if ($this->targetWidth && $this->targetHeight) {
+            $scaledHelper = $scaledHelper->setDimensions(round($factor * $this->targetWidth), round($factor * $this->targetHeight));
+        } elseif ($this->targetWidth) {
+            $scaledHelper = $scaledHelper->setWidth(round($factor * $this->targetWidth));
+        } elseif ($this->targetHeight) {
+            $scaledHelper = $scaledHelper->setHeight(round($factor * $this->targetHeight));
+        } else {
+            $scaledHelper = $scaledHelper->setWidth(round($factor * $this->baseWidth));
+        }
+
+        return $scaledHelper;
+    }
+
+    /**
+     * @return int
+     */
+    public function getCurrentWidth() : int
+    {
+        if ($this->targetWidth) {
+            return $this->targetWidth;
+        } elseif ($this->targetHeight) {
+            return round($this->targetHeight * $this->baseWidth/ $this->baseHeight);
+        } else {
+            return $this->baseWidth;
+        }
+    }
+
+
+    /**
+     * @return int
+     */
+    public function getCurrentHeight() : int
+    {
+        if ($this->targetHeight) {
+            return $this->targetHeight;
+        } elseif ($this->targetWidth) {
+            return round($this->targetWidth *  $this->baseHeight / $this->baseWidth);
+        } else {
+            return $this->baseHeight;
+        }
+    }
+
+}

--- a/Classes/EelHelpers/AssetImageSourceHelper.php
+++ b/Classes/EelHelpers/AssetImageSourceHelper.php
@@ -8,7 +8,7 @@ use Neos\Media\Domain\Service\ThumbnailService;
 use Neos\Media\Domain\Model\ThumbnailConfiguration;
 use Neos\Flow\Mvc\ActionRequest;
 
-class AssetImageSourceHelper extends AbstractImageSourceHelper implements ScalableImageSourceHelperInterface
+class AssetImageSourceHelper extends AbstractScalableImageSourceHelper
 {
 
     /**
@@ -45,6 +45,8 @@ class AssetImageSourceHelper extends AbstractImageSourceHelper implements Scalab
     public function __construct(ImageInterface $asset)
     {
         $this->asset = $asset;
+        $this->baseWidth = $this->asset->getWidth();
+        $this->baseHeight = $this->asset->getHeight();
     }
 
 
@@ -64,25 +66,12 @@ class AssetImageSourceHelper extends AbstractImageSourceHelper implements Scalab
         $this->request = $request;
     }
 
-    public function scale(float $factor): ImageSourceHelperInterface
-    {
-        $scaledHelper = clone($this);
-
-        if ($this->targetWidth) {
-            $scaledHelper = $scaledHelper->setWidth(round($factor * $this->targetWidth));
-        } else {
-            $scaledHelper = $scaledHelper->setWidth(round($factor * $this->asset->getWidth()));
-        }
-
-        if ($this->targetHeight) {
-            $scaledHelper = $scaledHelper->setHeight(round($factor * $this->targetHeight));
-        } else if (!$this->targetWidth) {
-            $scaledHelper = $scaledHelper->setHeight(round($factor * $this->asset->getHeight()));
-        }
-
-        return $scaledHelper;
-    }
-
+    /**
+     * @return string
+     * @throws \Neos\Flow\Mvc\Routing\Exception\MissingActionNameException
+     * @throws \Neos\Media\Exception\AssetServiceException
+     * @throws \Neos\Media\Exception\ThumbnailServiceException
+     */
     public function src(): string
     {
         $async = $this->request ? $this->async : false;
@@ -112,26 +101,5 @@ class AssetImageSourceHelper extends AbstractImageSourceHelper implements Scalab
         return $thumbnailData['src'];
     }
 
-    public function getCurrentWidth() : int
-    {
-        if ($this->targetWidth) {
-            return $this->targetWidth;
-        } elseif ($this->targetHeight) {
-            return round($this->targetHeight * $this->asset->getWidth() / $this->asset->getHeight());
-        } else {
-            return $this->asset->getWidth();
-        }
-    }
 
-
-    public function getCurrentHeight() : int
-    {
-        if ($this->targetHeight) {
-            return $this->targetHeight;
-        } elseif ($this->targetWidth) {
-            return round($this->targetWidth *  $this->asset->getHeight() / $this->asset->getWidth());
-        } else {
-            return $this->asset->getHeight();
-        }
-    }
 }

--- a/Classes/EelHelpers/DummyImageSourceHelper.php
+++ b/Classes/EelHelpers/DummyImageSourceHelper.php
@@ -3,7 +3,7 @@ namespace Sitegeist\Kaleidoscope\EelHelpers;
 
 use Neos\Flow\Annotations as Flow;
 
-class DummyImageSourceHelper extends AbstractImageSourceHelper implements ScalableImageSourceHelperInterface
+class DummyImageSourceHelper extends AbstractScalableImageSourceHelper
 {
     protected $baseWidth = 600;
 
@@ -65,22 +65,9 @@ class DummyImageSourceHelper extends AbstractImageSourceHelper implements Scalab
         $this->text = $text;
     }
 
-    public function scale(float $factor): ImageSourceHelperInterface
-    {
-        $scaledHelper = clone($this);
-        $scaledHelper->setBaseWidth(round($factor * $this->baseWidth));
-        $scaledHelper->setBaseHeight(round($factor * $this->baseHeight));
-
-        if ($this->targetWidth) {
-            $scaledHelper = $scaledHelper->setWidth(round($factor * $this->targetWidth));
-        }
-        if ($this->targetHeight) {
-            $scaledHelper = $scaledHelper->setHeight(round($factor * $this->targetHeight));
-        }
-
-        return $scaledHelper;
-    }
-
+    /**
+     * @return string
+     */
     public function src(): string
     {
         $uri = $this->baseUri . '?' . http_build_query (
@@ -93,28 +80,5 @@ class DummyImageSourceHelper extends AbstractImageSourceHelper implements Scalab
             ]
         );
         return $uri;
-    }
-
-    public function getCurrentWidth() : int
-    {
-        if ($this->targetWidth) {
-            return $this->targetWidth;
-        } elseif ($this->targetHeight) {
-            return round($this->targetHeight * $this->baseWidth / $this->baseHeight);
-        } else {
-            return $this->baseWidth;
-        }
-    }
-
-
-    public function getCurrentHeight() : int
-    {
-        if ($this->targetHeight) {
-            return $this->targetHeight;
-        } elseif ($this->targetWidth) {
-            return round($this->targetWidth * $this->baseHeight / $this->baseWidth);
-        } else {
-            return $this->baseHeight;
-        }
     }
 }

--- a/Classes/EelHelpers/ImageSourceHelperInterface.php
+++ b/Classes/EelHelpers/ImageSourceHelperInterface.php
@@ -5,9 +5,11 @@ use Neos\Eel\ProtectedContextAwareInterface;
 
 interface ImageSourceHelperInterface extends ProtectedContextAwareInterface
 {
-    public function setWidth(int $width = null) : ImageSourceHelperInterface;
+    public function setWidth(int $width = null, bool $preserveAspect = false) : ImageSourceHelperInterface;
 
-    public function setHeight(int $height = null) : ImageSourceHelperInterface;
+    public function setHeight(int $height = null, bool $preserveAspect = false) : ImageSourceHelperInterface;
+
+    public function setDimensions(int $width = null, int $height = null) : ImageSourceHelperInterface;
 
     public function applyPreset(string $name) : ImageSourceHelperInterface;
 

--- a/Classes/EelHelpers/UriImageSourceHelper.php
+++ b/Classes/EelHelpers/UriImageSourceHelper.php
@@ -24,6 +24,9 @@ class UriImageSourceHelper extends AbstractImageSourceHelper
         $this->uri = $uri;
     }
 
+    /**
+     * @return string
+     */
     public function src(): string
     {
         return $this->uri;

--- a/README.md
+++ b/README.md
@@ -274,8 +274,9 @@ dimensions and to render the `src` and `srcset`-attributes.
 Methods of ImageSource-Helpers that are accessible via EEL:
 
 - `applyPreset( string )`: Set width and/or height via named-preset from Settings `Neos.Media.thumbnailPresets`
-- `setWidth( integer )`: Set the intend width
-- `setHeight( integer )`: Set the intended height
+- `setWidth( integer $width, bool $preserveAspect = false )`: Set the intend width modify height aswell if 
+- `setHeight( integer $height, bool $preserveAspect = false )`: Set the intended height
+- `setDimensions( integer, interger)`: Set the intended width and height
 - `src ()` : Render a src attribute for the given ImageSource-object
 - `srcset ( array of descriptors )` : render a srcset attribute for the ImageSource with given media descriptors like `2.x` or `800w`
 


### PR DESCRIPTION
* `setDimensions` allows to set width and height at once
* `preserveAspect` on `setWidth` and `setHeight` will make sure the current aspect of the image as defined by base/target width  and height is perserved during the operation