### PR TITLE
FEATURE: Use × instead of x

### DIFF
--- a/Classes/Controller/DummyImageController.php
+++ b/Classes/Controller/DummyImageController.php
@@ -98,7 +98,7 @@ class DummyImageController extends ActionController
             }
 
             if ($renderText) {
-                $text = trim((string)$t) ?: sprintf('%s x %s', $width, $height);
+                $text = trim((string)$t) ?: sprintf('%s×%s', $width, $height);
                 $this->renderText($image, $foregroundColor, $width, $height, $text, $renderShape ? false : true);
             }
 


### PR DESCRIPTION
This change uses the multiplicator sign `×` instead of ` x `. A further benefit that we can save two spaces.

## Before
![before](https://user-images.githubusercontent.com/4510166/83002163-02c97e80-a00d-11ea-9db9-db7aebcb7e96.png)

## After
![after](https://user-images.githubusercontent.com/4510166/83002187-0957f600-a00d-11ea-8e47-a084534a1a04.png)
