### PR TITLE
!!! FEATURE: Add props `renderDimensionAttributes`, `width`, `height`, `loading` and `format` resp. `formats`

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Props:
 - `alt`: alt-attribute for the img tag
 - `title`: title attribute for the img tag
 - `class`: class attribute for the img tag
-- `dimensions`: render dimension attributes (width/height) when the data is available from the imageSource. Enabled by default
+- `renderDimensionAttributes`: render dimension attributes (width/height) when the data is available from the imageSource. Enabled by default
 
 #### Image with srcset in multiple resolutions:
 
@@ -114,15 +114,15 @@ Props:
    - `height`: (optional) the base height, will be applied to the `imageSource`   
 - `srcset`: media descriptors like '1.5x' or '600w' of the default image (string ot array)
 - `sizes`: sizes attribute of the default image (string ot array)
-- `formats`: image formats that will be rendered as sources of separate type (string or array)
+- `formats`: (optional) image formats that will be rendered as sources of separate type (string or array)
 - `width`: (optional) the base width, will be applied to the `imageSource`
 - `height`: (optional) the base height, will be applied to the `imageSource`   
 - `loading`: (optional) loading attribute for the img tag 
 - `alt`: alt-attribute for the img tag
 - `title`: title attribute for the img tag
 - `class`: class attribute for the picture tag
-- `dimensions`: render dimension attributes (width/height) for the img-tag when the data is available from the imageSource
-  if not specified dimensions will be enabled automatically for pictures that only use the `formats` options.
+- `renderDimensionAttributes`: render dimension attributes (width/height) for the img-tag when the data is available from the imageSource
+  if not specified renderDimensionAttributes will be enabled automatically for pictures that only use the `formats` options.
 
 #### Picture multiple formats:
 

--- a/README.md
+++ b/README.md
@@ -5,16 +5,15 @@
 This package implements responsive-images for Neos for being used via Fusion.
 
 ```
-imageSource = Sitegeist.Kaleidoscope:DummyImageSource {
-    width = 800
-    height = 200
-}
+imageSource = Sitegeist.Kaleidoscope:DummyImageSource
 
 renderer = afx`
     <Sitegeist.Kaleidoscope:Image
         imageSource={props.imageSource}
         srcset="320w, 400w, 600w, 800w, 1000w, 1200w, 1600w"
         sizes="(min-width: 800px) 1000px, (min-width: 480px) 800px, (min-width: 320px) 440px, 100vw"
+        width="400"
+        height="400"
     />
 `
 ```
@@ -62,6 +61,10 @@ Props:
 - `imageSource`: the imageSource to render
 - `srcset`: media descriptors like '1.5x' or '600w' of the default image (string ot array)
 - `sizes`: sizes attribute of the default image (string ot array)
+- `loading`: (optional) loading attribute for the img tag 
+- `format`: (optional) the image-format like `webp` or `png`, will be applied to the `imageSource`
+- `width`: (optional) the base width, will be applied to the `imageSource`    
+- `height`: (optional) the base height, will be applied to the `imageSource`    
 - `alt`: alt-attribute for the img tag
 - `title`: title attribute for the img tag
 - `class`: class attribute for the img tag
@@ -117,16 +120,21 @@ Props:
 - `imageSource`: the imageSource to render
 - `sources`: an array of source definitions that supports the following keys
    - `imageSource`: alternate image-source for art direction purpose
-   - `srcset`: media descriptors like '1.5x' or '600w' (string ot array)
-   - `sizes`: sizes attribute (string or array)
-   - `media`: the media attribute for this source
-   - `type`: the type attribute for this source
-   - `format`: the image-format for the source like `webp` or `png`, is applied to `imageSource` and `type`
+   - `srcset`: (optional) media descriptors like '1.5x' or '600w' (string ot array)
+   - `sizes`: (optional) sizes attribute (string or array)
+   - `media`: (optional) the media attribute for this source
+   - `type`: (optional) the type attribute for this source
+   - `format`: (optional) the image-format for the source like `webp` or `png`, is applied to `imageSource` and `type`
+   - `width`: (optional) the base width, will be applied to the `imageSource`    
+   - `height`: (optional) the base height, will be applied to the `imageSource`   
 - `srcset`: media descriptors like '1.5x' or '600w' of the default image (string ot array)
 - `sizes`: sizes attribute of the default image (string ot array)
-- `formats`: image formats that will be rendered as sources of separate type (string or array) 
-- `alt`: alt-attribute for the picture tag
-- `title`: title attribute for the picture tag
+- `formats`: image formats that will be rendered as sources of separate type (string or array)
+- `width`: (optional) the base width, will be applied to the `imageSource`
+- `height`: (optional) the base height, will be applied to the `imageSource`   
+- `loading`: (optional) loading attribute for the img tag 
+- `alt`: alt-attribute for the img tag
+- `title`: title attribute for the img tag
 - `class`: class attribute for the picture tag
 - `dimensions`: render dimension attributes (width/height) for the img-tag when the data is available from the imageSource
   if not specified dimensions will be enabled automatically for pictures that only use the `formats` options.
@@ -190,7 +198,9 @@ Props:
 - `imageSource`: the imageSource to render (inherited from picture)
 - `srcset`: media descriptors like '1.5x' or '600w' of the default image (string ot array, inherited from picture)
 - `sizes`: (optional) sizes attribute (string or array, inherited from picture)
-- `format`: (optional) the image-format like `webp` or `png`, will be applied to `imageSource` and `type`   
+- `format`: (optional) the image-format like `webp` or `png`, will be applied to `imageSource` and `type`
+- `width`: (optional) the base width, will be applied to the `imageSource`    
+- `height`: (optional) the base height, will be applied to the `imageSource`    
 - `type`: (optional) the type attribute for the source like `image/png` or `image/webp`, the actual format is enforced via `imageSource.setFormat()`
 - `media`: (optional) the media query for the given source
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Props:
    - `sizes`: sizes attribute (string or array)
    - `media`: the media attribute for this source
    - `type`: the type attribute for this source
+   - `format`: the image-format for the source like `webp` or `png`, is applied to `imageSource` and `type`
 - `srcset`: media descriptors like '1.5x' or '600w' of the default image (string ot array)
 - `sizes`: sizes attribute of the default image (string ot array)
 - `formats`: image formats that will be rendered as sources of separate type (string or array) 
@@ -150,69 +151,46 @@ renderer = afx`
 
 #### Picture with multiple sources:
 
+The properties  `imageSource`. `srcset` and `sizes` are automatically passed from the
+picture to the source if not defined otherwise.
+
 ```
 imageSource = Sitegeist.Kaleidoscope:DummyImageSource
-sources = Neos.Fusion:RawArray {
-    large = Neos.Fusion:RawArray {
-        srcset = '1x, 1.5x, 2x'
-        media = 'screen and (min-width: 1600px)'
-    }
-
-    small = Neos.Fusion:RawArray {
-        srcset = '320w, 480w, 800w'
-        sizes = '(max-width: 320px) 280px, (max-width: 480px) 440px, 100vw'
-        media = 'screen and (max-width: 1599px)'
-    }
-
-    webp = Neos.Fusion:RawArray {
-        imageSource = ${props.imageSource.setFormat('webp')} 
-        srcset = '320w, 480w, 800w'
-        sizes = '(max-width: 320px) 280px, (max-width: 480px) 440px, 100vw'
-        type = 'image/webp'
-    }
-
-    print = Neos.Fusion:RawArray {
-        imageSource = Sitegeist.Kaleidoscope:DummyImageSource {
-            text = "im am here for printing"
-        }
-        media = 'print'
-    }
-}
 
 renderer = afx`
-    <Sitegeist.Kaleidoscope:Picture imageSource={props.imageSource} sources={props.sources} />
+    <Sitegeist.Kaleidoscope:Picture imageSource={props.imageSource} >
+        <Sitegeist.Kaleidoscope:Source 
+            srcset="1x, 1.5x, 2x" 
+            media="screen and (min-width: 1600px)"
+            />
+        <Sitegeist.Kaleidoscope:Source 
+            srcset="320w, 480w, 800w"
+            sizes="(max-width: 320px) 280px, (max-width: 480px) 440px, 100vw"
+            media="screen and (max-width: 1599px)"
+            />
+        <Sitegeist.Kaleidoscope:Source 
+            format="webp"
+            srcset = '320w, 480w, 800w'
+            sizes = '(max-width: 320px) 280px, (max-width: 480px) 440px, 100vw' 
+            />
+        <Sitegeist.Kaleidoscope:Source 
+            imageSource={props.alternatePintImage} 
+            media="print" 
+            />
+    </Sitegeist.Kaleidoscope:Picture>
 `
 ```
 
-will render as:
-
-```
-<picture>
-  <source
-    srcset="_large_url_1_ 1x, _large_url_2_ 1.5x, _large_url_3_ 2x"
-    media="screen and (min-width: 1600px)"
-    />
-  <source
-    srcset="_small_url_1_ 320w, _small_url_2_ 480w, _small_url_3_ 800w, _small_url_4_ 1000w"
-    sizes="(max-width: 320px) 280px, (max-width: 480px) 440px, 800px"
-    media="screen and (max-width: 1599px)"
-    />
-  <source
-    srcset="_print_url_1_"
-    media="print"
-    />
-  <img src="_base_url_">
-</picture>
-```
 ### `Sitegeist.Kaleidoscope:Source`
 
 Render an `src`-tag with `srcset`, `sizes`, `type` and `media` attributes.
 
 Props:
 
-- `imageSource`: the imageSource to render
-- `srcset`: media descriptors like '1.5x' or '600w' of the default image (string ot array)
-- `sizes`: (optional) sizes attribute (string or array)
+- `imageSource`: the imageSource to render (inherited from picture)
+- `srcset`: media descriptors like '1.5x' or '600w' of the default image (string ot array, inherited from picture)
+- `sizes`: (optional) sizes attribute (string or array, inherited from picture)
+- `format`: (optional) the image-format like `webp` or `png`, will be applied to `imageSource` and `type`   
 - `type`: (optional) the type attribute for the source like `image/png` or `image/webp`, the actual format is enforced via `imageSource.setFormat()`
 - `media`: (optional) the media query for the given source
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Props:
 - `alt`: alt-attribute for the img tag
 - `title`: title attribute for the img tag
 - `class`: class attribute for the img tag
+- `dimensions`: render dimension attributes (width/height) when the data is available from the imageSource. Enabled by default
 
 #### Image with srcset in multiple resolutions:
 
@@ -122,9 +123,32 @@ Props:
    - `type`: the type attribute for this source
 - `srcset`: media descriptors like '1.5x' or '600w' of the default image (string ot array)
 - `sizes`: sizes attribute of the default image (string ot array)
+- `formats`: image formats that will be rendered as sources of separate type (string or array) 
 - `alt`: alt-attribute for the picture tag
 - `title`: title attribute for the picture tag
 - `class`: class attribute for the picture tag
+- `dimensions`: render dimension attributes (width/height) for the img-tag when the data is available from the imageSource
+  if not specified dimensions will be enabled automatically for pictures that only use the `formats` options.
+
+#### Picture multiple formats:
+
+The following code will render a picture with an img-tag and two additional
+source-tags for the formats webp and png in addition to the default img. 
+
+```
+imageSource = Sitegeist.Kaleidoscope:DummyImageSource
+
+renderer = afx`
+    <Sitegeist.Kaleidoscope:Picture
+        imageSource={props.imageSource}
+        srcset="320w, 600w, 800w, 1200w, 1600w"
+        sizes="(min-width: 320px) 440px, 100vw"
+        formats="webp, png'
+        />
+`
+```
+
+#### Picture with multiple sources:
 
 ```
 imageSource = Sitegeist.Kaleidoscope:DummyImageSource

--- a/Resources/Private/Fusion/Prototypes/Image.fusion
+++ b/Resources/Private/Fusion/Prototypes/Image.fusion
@@ -45,20 +45,42 @@ prototype(Sitegeist.Kaleidoscope:Image) < prototype(Neos.Fusion:Component) {
     alt = null
     title = null
     class = null
+    loading = null
+    width = null
+    height = null
+    format = null
     dimensions = true
 
-    renderer = afx`
-        <img @if.has={props.imageSource}
-            src={props.imageSource}
-            srcset={props.imageSource.srcset(props.srcset)}
-            srcset.@if.has={props.srcset}
-            sizes={props.sizes}
-            sizes.@process.join={Type.isArray(value) ? Array.join(value, ', ') : value}
-            class={props.class}
-            alt={props.alt}
-            title={props.title}
-            width={props.dimensions ? props.imageSource.currentWidth : null}
-            height={props.dimensions ? props.imageSource.currentHeight : null}
-        />
-    `
+    renderer = Neos.Fusion:Component {
+
+        # apply format, width and height to the imageSource
+        imageSource = ${props.imageSource}
+        imageSource.@process.applyWidth = ${props.width ? value.setWidth(props.width) : value}
+        imageSource.@process.applyHeight = ${props.height ? value.setHeight(props.height) : value}
+        imageSource.@process.applyFormat = ${props.format ? value.setFormat(props.format) : value}
+
+        srcset = ${props.srcset}
+        sizes = ${props.sizes}
+        loading = ${props.loading}
+        alt =  ${props.alt}
+        title = ${props.title}
+        class = ${props.class}
+        dimensions = ${props.dimensions}
+
+        renderer = afx`
+            <img @if.has={props.imageSource}
+                src={props.imageSource.src()}
+                srcset={props.imageSource.srcset(props.srcset)}
+                srcset.@if.has={props.srcset}
+                sizes={props.sizes}
+                sizes.@process.join={Type.isArray(value) ? Array.join(value, ', ') : value}
+                loading={props.loading}
+                class={props.class}
+                alt={props.alt}
+                title={props.title}
+                width={props.dimensions ? props.imageSource.currentWidth : null}
+                height={props.dimensions ? props.imageSource.currentHeight : null}
+            />
+        `
+    }
 }

--- a/Resources/Private/Fusion/Prototypes/Image.fusion
+++ b/Resources/Private/Fusion/Prototypes/Image.fusion
@@ -45,6 +45,7 @@ prototype(Sitegeist.Kaleidoscope:Image) < prototype(Neos.Fusion:Component) {
     alt = null
     title = null
     class = null
+    dimensions = true
 
     renderer = afx`
         <img @if.has={props.imageSource}
@@ -56,6 +57,8 @@ prototype(Sitegeist.Kaleidoscope:Image) < prototype(Neos.Fusion:Component) {
             class={props.class}
             alt={props.alt}
             title={props.title}
+            width={props.dimensions ? props.imageSource.currentWidth : null}
+            height={props.dimensions ? props.imageSource.currentHeight : null}
         />
     `
 }

--- a/Resources/Private/Fusion/Prototypes/Image.fusion
+++ b/Resources/Private/Fusion/Prototypes/Image.fusion
@@ -49,9 +49,10 @@ prototype(Sitegeist.Kaleidoscope:Image) < prototype(Neos.Fusion:Component) {
     width = null
     height = null
     format = null
-    dimensions = true
+    renderDimensionAttributes = true
 
     renderer = Neos.Fusion:Component {
+        @if.hasImageSource = ${props.imageSource && Type.instance(props.imageSource, '\\Sitegeist\\Kaleidoscope\\EelHelpers\\ImageSourceHelperInterface')}
 
         # apply format, width and height to the imageSource
         imageSource = ${props.imageSource}
@@ -65,10 +66,10 @@ prototype(Sitegeist.Kaleidoscope:Image) < prototype(Neos.Fusion:Component) {
         alt =  ${props.alt}
         title = ${props.title}
         class = ${props.class}
-        dimensions = ${props.dimensions}
+        renderDimensionAttributes = ${props.renderDimensionAttributes}
 
         renderer = afx`
-            <img @if.has={props.imageSource}
+            <img
                 src={props.imageSource.src()}
                 srcset={props.imageSource.srcset(props.srcset)}
                 srcset.@if.has={props.srcset}
@@ -78,8 +79,8 @@ prototype(Sitegeist.Kaleidoscope:Image) < prototype(Neos.Fusion:Component) {
                 class={props.class}
                 alt={props.alt}
                 title={props.title}
-                width={props.dimensions ? props.imageSource.currentWidth : null}
-                height={props.dimensions ? props.imageSource.currentHeight : null}
+                width={props.renderDimensionAttributes ? props.imageSource.currentWidth : null}
+                height={props.renderDimensionAttributes ? props.imageSource.currentHeight : null}
             />
         `
     }

--- a/Resources/Private/Fusion/Prototypes/Picture.fusion
+++ b/Resources/Private/Fusion/Prototypes/Picture.fusion
@@ -73,7 +73,7 @@ prototype(Sitegeist.Kaleidoscope:Picture) < prototype(Neos.Fusion:Component) {
         title = ${props.title}
         class = ${props.class}
         content = ${props.content}
-        dimensions = ${props.dimensions}
+        dimensions = ${Type.isBoolean(props.dimensions) ? props.dimensions : (!props.content && !props.sources)}
 
         renderer = afx`
             <picture @if.has={props.imageSource} class={props.class}>
@@ -104,9 +104,7 @@ prototype(Sitegeist.Kaleidoscope:Picture) < prototype(Neos.Fusion:Component) {
                     loading={props.loading}
                     alt={props.alt}
                     title={props.title}
-                    dimensions={props.formats && !props.content && !props.sources}
-                    dimensions.@override.fromProps={props.dimensions}
-                    dimensions.@override.fromProps.@if.isBoolean={Type.isBoolean(props.dimensions)}
+                    dimensions={props.dimensions}
                 />
             </picture>
         `

--- a/Resources/Private/Fusion/Prototypes/Picture.fusion
+++ b/Resources/Private/Fusion/Prototypes/Picture.fusion
@@ -33,15 +33,17 @@ prototype(Sitegeist.Kaleidoscope:Picture) < prototype(Neos.Fusion:Component) {
     srcset = null
     sizes = null
     sources = null
+    formats = null
     alt = null
     title = null
     class = null
     content = ''
+    dimensions = null
 
     renderer = afx`
         <picture @if.has={props.imageSource} class={props.class}>
             {props.content}
-            <Neos.Fusion:Collection collection={props.sources} itemName="source" @children="itemRenderer" @if.has={props.sources}>
+            <Neos.Fusion:Collection collection={props.sources} itemName="source" @if.has={props.sources}>
                 <Sitegeist.Kaleidoscope:Source
                     imageSource={source.imageSource ? source.imageSource : props.imageSource}
                     type={source.type}
@@ -50,12 +52,27 @@ prototype(Sitegeist.Kaleidoscope:Picture) < prototype(Neos.Fusion:Component) {
                     sizes={source.sizes ? source.sizes : props.sizes}
                 />
             </Neos.Fusion:Collection>
+            <Neos.Fusion:Collection
+                @if.has={props.imageSource && props.formats}
+                collection={Type.isArray(props.formats) ? props.formats : String.split(props.formats, ',')}
+                itemName="format"
+            >
+                <Sitegeist.Kaleidoscope:Source
+                    imageSource={props.imageSource.setFormat(String.trim(format))}
+                    type={'image/' + String.trim(format)}
+                    srcset={props.srcset}
+                    sizes={props.sizes}
+                />
+            </Neos.Fusion:Collection>
             <Sitegeist.Kaleidoscope:Image
                 imageSource={props.imageSource}
                 sizes={props.sizes}
                 srcset={props.srcset}
                 alt={props.alt}
                 title={props.title}
+                dimensions={props.formats && !props.content && !props.sources}
+                dimensions.@override.fromProps={props.dimensions}
+                dimensions.@override.fromProps.@if.isBoolean={Type.isBoolean(props.dimensions)}
             />
         </picture>
     `

--- a/Resources/Private/Fusion/Prototypes/Picture.fusion
+++ b/Resources/Private/Fusion/Prototypes/Picture.fusion
@@ -41,7 +41,7 @@ prototype(Sitegeist.Kaleidoscope:Picture) < prototype(Neos.Fusion:Component) {
     title = null
     class = null
     content = ''
-    dimensions = null
+    renderDimensionAttributes = null
 
     #
     # put the values that shall be applied to sources automatically to the context
@@ -57,6 +57,7 @@ prototype(Sitegeist.Kaleidoscope:Picture) < prototype(Neos.Fusion:Component) {
     }
 
     renderer = Neos.Fusion:Component {
+        @if.hasImageSource = ${props.imageSource && Type.instance(props.imageSource, '\\Sitegeist\\Kaleidoscope\\EelHelpers\\ImageSourceHelperInterface')}
 
         # apply format, width and height to the imageSource
         imageSource = ${props.imageSource}
@@ -73,10 +74,10 @@ prototype(Sitegeist.Kaleidoscope:Picture) < prototype(Neos.Fusion:Component) {
         title = ${props.title}
         class = ${props.class}
         content = ${props.content}
-        dimensions = ${Type.isBoolean(props.dimensions) ? props.dimensions : (!props.content && !props.sources)}
+        renderDimensionAttributes = ${Type.isBoolean(props.renderDimensionAttributes) ? props.renderDimensionAttributes : (!props.content && !props.sources)}
 
         renderer = afx`
-            <picture @if.has={props.imageSource} class={props.class}>
+            <picture class={props.class}>
                 {props.content}
                 <Neos.Fusion:Collection collection={props.sources} itemName="source" @if.has={props.sources}>
                     <Sitegeist.Kaleidoscope:Source
@@ -104,7 +105,7 @@ prototype(Sitegeist.Kaleidoscope:Picture) < prototype(Neos.Fusion:Component) {
                     loading={props.loading}
                     alt={props.alt}
                     title={props.title}
-                    dimensions={props.dimensions}
+                    renderDimensionAttributes={props.renderDimensionAttributes}
                 />
             </picture>
         `

--- a/Resources/Private/Fusion/Prototypes/Picture.fusion
+++ b/Resources/Private/Fusion/Prototypes/Picture.fusion
@@ -29,9 +29,10 @@ prototype(Sitegeist.Kaleidoscope:Picture) < prototype(Neos.Fusion:Component) {
         }
     }
 
-    imageSource = Sitegeist.Kaleidoscope:DummyImageSource
+    imageSource = null
     srcset = null
     sizes = null
+    loading = null
     sources = null
     formats = null
     alt = null
@@ -48,38 +49,62 @@ prototype(Sitegeist.Kaleidoscope:Picture) < prototype(Neos.Fusion:Component) {
         __imageSource = ${this.imageSource}
         __srcset = ${this.srcset}
         __sizes = ${this.sizes}
+        __width = ${this.width}
+        __height = ${this.height}
+        __format = ${this.format}
     }
 
-    renderer = afx`
-        <picture @if.has={props.imageSource} class={props.class}>
-            {props.content}
-            <Neos.Fusion:Collection collection={props.sources} itemName="source" @if.has={props.sources}>
-                <Sitegeist.Kaleidoscope:Source
-                    imageSource={source.imageSource ? source.imageSource : props.imageSource}
-                    type={source.type}
-                    media={source.media}
-                    format={source.format}
-                    srcset={source.srcset ? source.srcset : props.srcset}
-                    sizes={source.sizes ? source.sizes : props.sizes}
+    renderer = Neos.Fusion:Component {
+
+        # apply format, width and height to the imageSource
+        imageSource = ${props.imageSource}
+        imageSource.@process.applyWidth = ${props.width ? value.setWidth(props.width) : value}
+        imageSource.@process.applyHeight = ${props.height ? value.setHeight(props.height) : value}
+        imageSource.@process.applyFormat = ${props.format ? value.setFormat(props.format) : value}
+
+        srcset = ${props.srcset}
+        sizes = ${props.sizes}
+        loading = ${props.loading}
+        sources = ${props.sources}
+        formats = ${props.formats}
+        alt = ${props.alt}
+        title = ${props.title}
+        class = ${props.class}
+        content = ${props.content}
+        dimensions = ${props.dimensions}
+
+        renderer = afx`
+            <picture @if.has={props.imageSource} class={props.class}>
+                {props.content}
+                <Neos.Fusion:Collection collection={props.sources} itemName="source" @if.has={props.sources}>
+                    <Sitegeist.Kaleidoscope:Source
+                        imageSource={source.imageSource ? source.imageSource : props.imageSource}
+                        type={source.type}
+                        media={source.media}
+                        format={source.format}
+                        srcset={source.srcset ? source.srcset : props.srcset}
+                        sizes={source.sizes ? source.sizes : props.sizes}
+                    />
+                </Neos.Fusion:Collection>
+                <Neos.Fusion:Collection
+                    @if.has={props.imageSource && props.formats}
+                    collection={Type.isArray(props.formats) ? props.formats : String.split(props.formats, ',')}
+                    itemName="format"
+                >
+                    <Sitegeist.Kaleidoscope:Source format={String.trim(format)} />
+                </Neos.Fusion:Collection>
+                <Sitegeist.Kaleidoscope:Image
+                    imageSource={props.imageSource}
+                    sizes={props.sizes}
+                    srcset={props.srcset}
+                    loading={props.loading}
+                    alt={props.alt}
+                    title={props.title}
+                    dimensions={props.formats && !props.content && !props.sources}
+                    dimensions.@override.fromProps={props.dimensions}
+                    dimensions.@override.fromProps.@if.isBoolean={Type.isBoolean(props.dimensions)}
                 />
-            </Neos.Fusion:Collection>
-            <Neos.Fusion:Collection
-                @if.has={props.imageSource && props.formats}
-                collection={Type.isArray(props.formats) ? props.formats : String.split(props.formats, ',')}
-                itemName="format"
-            >
-                <Sitegeist.Kaleidoscope:Source format={String.trim(format)} />
-            </Neos.Fusion:Collection>
-            <Sitegeist.Kaleidoscope:Image
-                imageSource={props.imageSource}
-                sizes={props.sizes}
-                srcset={props.srcset}
-                alt={props.alt}
-                title={props.title}
-                dimensions={props.formats && !props.content && !props.sources}
-                dimensions.@override.fromProps={props.dimensions}
-                dimensions.@override.fromProps.@if.isBoolean={Type.isBoolean(props.dimensions)}
-            />
-        </picture>
-    `
+            </picture>
+        `
+    }
 }

--- a/Resources/Private/Fusion/Prototypes/Picture.fusion
+++ b/Resources/Private/Fusion/Prototypes/Picture.fusion
@@ -40,6 +40,10 @@ prototype(Sitegeist.Kaleidoscope:Picture) < prototype(Neos.Fusion:Component) {
     content = ''
     dimensions = null
 
+    #
+    # put the values that shall be applied to sources automatically to the context
+    # to make them available to all props during evaluation
+    #
     @context {
         __imageSource = ${this.imageSource}
         __srcset = ${this.srcset}

--- a/Resources/Private/Fusion/Prototypes/Picture.fusion
+++ b/Resources/Private/Fusion/Prototypes/Picture.fusion
@@ -35,6 +35,8 @@ prototype(Sitegeist.Kaleidoscope:Picture) < prototype(Neos.Fusion:Component) {
     loading = null
     sources = null
     formats = null
+    width = null
+    height = null
     alt = null
     title = null
     class = null
@@ -82,6 +84,8 @@ prototype(Sitegeist.Kaleidoscope:Picture) < prototype(Neos.Fusion:Component) {
                         type={source.type}
                         media={source.media}
                         format={source.format}
+                        width={source.width}
+                        height={source.height}
                         srcset={source.srcset ? source.srcset : props.srcset}
                         sizes={source.sizes ? source.sizes : props.sizes}
                     />

--- a/Resources/Private/Fusion/Prototypes/Picture.fusion
+++ b/Resources/Private/Fusion/Prototypes/Picture.fusion
@@ -40,6 +40,12 @@ prototype(Sitegeist.Kaleidoscope:Picture) < prototype(Neos.Fusion:Component) {
     content = ''
     dimensions = null
 
+    @context {
+        __imageSource = ${this.imageSource}
+        __srcset = ${this.srcset}
+        __sizes = ${this.sizes}
+    }
+
     renderer = afx`
         <picture @if.has={props.imageSource} class={props.class}>
             {props.content}
@@ -48,6 +54,7 @@ prototype(Sitegeist.Kaleidoscope:Picture) < prototype(Neos.Fusion:Component) {
                     imageSource={source.imageSource ? source.imageSource : props.imageSource}
                     type={source.type}
                     media={source.media}
+                    format={source.format}
                     srcset={source.srcset ? source.srcset : props.srcset}
                     sizes={source.sizes ? source.sizes : props.sizes}
                 />
@@ -57,12 +64,7 @@ prototype(Sitegeist.Kaleidoscope:Picture) < prototype(Neos.Fusion:Component) {
                 collection={Type.isArray(props.formats) ? props.formats : String.split(props.formats, ',')}
                 itemName="format"
             >
-                <Sitegeist.Kaleidoscope:Source
-                    imageSource={props.imageSource.setFormat(String.trim(format))}
-                    type={'image/' + String.trim(format)}
-                    srcset={props.srcset}
-                    sizes={props.sizes}
-                />
+                <Sitegeist.Kaleidoscope:Source format={String.trim(format)} />
             </Neos.Fusion:Collection>
             <Sitegeist.Kaleidoscope:Image
                 imageSource={props.imageSource}

--- a/Resources/Private/Fusion/Prototypes/Source.fusion
+++ b/Resources/Private/Fusion/Prototypes/Source.fusion
@@ -12,8 +12,17 @@ prototype(Sitegeist.Kaleidoscope:Source) < prototype(Neos.Fusion:Component) {
     format = null
 
     renderer = Neos.Fusion:Component {
-        imageSource = ${props.format ? props.imageSource.setFormat(props.format) : props.imageSource}
+
+        # apply the format to the imageSource
+        imageSource = ${props.imageSource}
+        imageSource.@process.applyFormat = ${value.setFormat(props.format)}
+        imageSource.@process.applyFormat.@if.hasFormat = ${props.format}
+
+        # apply the format to the type
         type = ${props.format ? 'image/' + props.format : props.type}
+        type.@process.applyFormat = ${'image/' + props.format}
+        type.@process.applyFormat.@if.hasFormat = ${props.format}
+
         srcset = ${props.srcset}
         sizes = ${props.sizes}
         media = ${props.media}

--- a/Resources/Private/Fusion/Prototypes/Source.fusion
+++ b/Resources/Private/Fusion/Prototypes/Source.fusion
@@ -4,20 +4,29 @@ prototype(Sitegeist.Kaleidoscope:Source) < prototype(Neos.Fusion:Component) {
         imageSource = ${PropTypes.instanceOf('\\Sitegeist\\Kaleidoscope\\EelHelpers\\ImageSourceHelperInterface')}
     }
 
-    imageSource = null
+    imageSource = ${__imageSource}
+    srcset = ${__srcset}
+    sizes = ${__sizes}
     type = null
     media = null
-    srcset = null
-    sizes = null
+    format = null
 
-    renderer = afx`
-        <source @if.has={props.imageSource}
-            srcset={props.imageSource.srcset(props.srcset)}
-            srcset.@if.has={props.srcset}
-            sizes={props.sizes}
-            sizes.@process.join={Type.isArray(value) ? Array.join(value, ', ') : value}
-            type={props.type}
-            media={props.media}
-        />
-    `
+    renderer = Neos.Fusion:Component {
+        imageSource = ${props.format ? props.imageSource.setFormat(props.format) : props.imageSource}
+        type = ${props.format ? 'image/' + props.format : props.type}
+        srcset = ${props.srcset}
+        sizes = ${props.sizes}
+        media = ${props.media}
+
+        renderer = afx`
+            <source @if.has={props.imageSource}
+                srcset={props.imageSource.srcset(props.srcset)}
+                srcset.@if.has={props.srcset}
+                sizes={props.sizes}
+                sizes.@process.join={Type.isArray(value) ? Array.join(value, ', ') : value}
+                type={props.type}
+                media={props.media}
+            />
+        `
+    }
 }

--- a/Resources/Private/Fusion/Prototypes/Source.fusion
+++ b/Resources/Private/Fusion/Prototypes/Source.fusion
@@ -5,36 +5,35 @@ prototype(Sitegeist.Kaleidoscope:Source) < prototype(Neos.Fusion:Component) {
     }
 
     imageSource = null
-    imageSource.@process.applyFromPicture = ${!value ? __imageSource : value}
     srcset = null
-    srcset.@process.applyFromPicture = ${!value ? __srcset : value}
     sizes = null
-    sizes.@process.applyFromPicture = ${!value ? __sizes : value}
     width = null
-    width.@process.applyFromPicture = ${!value ? __width : value}
     height = null
-    height.@process.applyFromPicture = ${!value ? __height : value}
     format = null
-    format.@process.applyFromPicture = ${!value ? __format : value}
     type = null
     media = null
 
-
     renderer = Neos.Fusion:Component {
 
-        # apply format, width and height to the imageSource
-        imageSource = ${props.imageSource}
-        imageSource.@process.applyWidth = ${props.width ? value.setWidth(props.width) : value}
-        imageSource.@process.applyHeight = ${props.height ? value.setHeight(props.height) : value}
-        imageSource.@process.applyFormat = ${props.format ? value.setFormat(props.format) : value}
+        @context {
+            imageSource = ${props.imageSource || __imageSource}
+            format = ${props.format || __format}
+            width = ${props.width || __width}
+            height = ${props.height || __height}
+            srcset = ${props.srcset || __srcset}
+            sizes = ${props.sizes || __sizes}
+        }
 
-        # apply the format to the type
-        type = ${props.format ? 'image/' + props.format : props.type}
-        type.@process.applyFormat = ${'image/' + props.format}
-        type.@process.applyFormat.@if.hasFormat = ${props.format}
+        @if.hasImageSource = ${imageSource && Type.instance(imageSource, '\\Sitegeist\\Kaleidoscope\\EelHelpers\\ImageSourceHelperInterface')}
 
-        srcset = ${props.srcset}
-        sizes = ${props.sizes}
+        imageSource = ${imageSource}
+        imageSource.@process.applyWidth = ${width ? value.setWidth(width) : value}
+        imageSource.@process.applyHeight = ${height ? value.setHeight(height) : value}
+        imageSource.@process.applyFormat = ${format ? value.setFormat(format) : value}
+
+        type = ${format ? 'image/' + format : props.type}
+        srcset = ${srcset}
+        sizes = ${srcset}
         media = ${props.media}
 
         renderer = afx`

--- a/Resources/Private/Fusion/Prototypes/Source.fusion
+++ b/Resources/Private/Fusion/Prototypes/Source.fusion
@@ -4,19 +4,24 @@ prototype(Sitegeist.Kaleidoscope:Source) < prototype(Neos.Fusion:Component) {
         imageSource = ${PropTypes.instanceOf('\\Sitegeist\\Kaleidoscope\\EelHelpers\\ImageSourceHelperInterface')}
     }
 
-    imageSource = ${__imageSource}
-    srcset = ${__srcset}
-    sizes = ${__sizes}
+    # reuse values put into context by picture
+    imageSource = ${__imageSource ? __imageSource : null}
+    srcset = ${__srcset  ? __srcset : null}
+    sizes = ${__sizes ? __sizes : null }
+    width = ${__width ? __width : null }
+    height = ${__height ? __height : null }
+    format = ${__format ? __format : null }
     type = null
     media = null
-    format = null
+
 
     renderer = Neos.Fusion:Component {
 
-        # apply the format to the imageSource
+        # apply format, width and height to the imageSource
         imageSource = ${props.imageSource}
-        imageSource.@process.applyFormat = ${value.setFormat(props.format)}
-        imageSource.@process.applyFormat.@if.hasFormat = ${props.format}
+        imageSource.@process.applyWidth = ${props.width ? value.setWidth(props.width) : value}
+        imageSource.@process.applyHeight = ${props.height ? value.setHeight(props.height) : value}
+        imageSource.@process.applyFormat = ${props.format ? value.setFormat(props.format) : value}
 
         # apply the format to the type
         type = ${props.format ? 'image/' + props.format : props.type}
@@ -29,6 +34,7 @@ prototype(Sitegeist.Kaleidoscope:Source) < prototype(Neos.Fusion:Component) {
 
         renderer = afx`
             <source @if.has={props.imageSource}
+                src={props.imageSource.src()}
                 srcset={props.imageSource.srcset(props.srcset)}
                 srcset.@if.has={props.srcset}
                 sizes={props.sizes}

--- a/Resources/Private/Fusion/Prototypes/Source.fusion
+++ b/Resources/Private/Fusion/Prototypes/Source.fusion
@@ -4,13 +4,18 @@ prototype(Sitegeist.Kaleidoscope:Source) < prototype(Neos.Fusion:Component) {
         imageSource = ${PropTypes.instanceOf('\\Sitegeist\\Kaleidoscope\\EelHelpers\\ImageSourceHelperInterface')}
     }
 
-    # reuse values put into context by picture
-    imageSource = ${__imageSource ? __imageSource : null}
-    srcset = ${__srcset  ? __srcset : null}
-    sizes = ${__sizes ? __sizes : null }
-    width = ${__width ? __width : null }
-    height = ${__height ? __height : null }
-    format = ${__format ? __format : null }
+    imageSource = null
+    imageSource.@process.applyFromPicture = ${!value ? __imageSource : value}
+    srcset = null
+    srcset.@process.applyFromPicture = ${!value ? __srcset : value}
+    sizes = null
+    sizes.@process.applyFromPicture = ${!value ? __sizes : value}
+    width = null
+    width.@process.applyFromPicture = ${!value ? __width : value}
+    height = null
+    height.@process.applyFromPicture = ${!value ? __height : value}
+    format = null
+    format.@process.applyFromPicture = ${!value ? __format : value}
     type = null
     media = null
 


### PR DESCRIPTION
### Sitegeist.Kaleidoscope:Image:

- `renderDimensionAttributes`: render dimension attributes (width/height) when the data is available from the imageSource. Enabled by default
- `loading`: (optional) loading attribute for the img tag 
- `width`: (optional) the base width, will be applied to the `imageSource`
- `height`: (optional) the base height, will be applied to the `imageSource`   
- `format`: (optional) the image-format like `webp` or `png`, is applied to the `imageSource`

### Sitegeist.Kaleidoscope:Picture:

- `renderDimensionAttributes`: render dimension attributes (width/height) for the img-tag when the data is available from the imageSource
  if not specified dimensions will be enabled automatically for pictures that only use the `formats` options.
- `formats`: (optional) image formats that will be rendered as sources of separate type (string or array)
- `loading`: (optional) loading attribute for the img tag 
- `width`: (optional) the base width, will be applied to the `imageSource`
- `height`: (optional) the base height, will be applied to the `imageSource`   

### Sitegeist.Kaleidoscope:Source:
- `format`: (optional) the image-format for the source like `webp` or `png`, is applied to `imageSource` and `type`
- `width`: (optional) the base width, will be applied to the `imageSource`
- `height`: (optional) the base height, will be applied to the `imageSource`   

In addition all Sitegeist.Kaleidoscope:Source rendered inside of a Sitegeist.Kaleidoscope:Picture
will inherit the values `imageSource`, `srcset` and `sizes`.
