### PR TITLE
BUGFIX: Update prop-assignment in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,11 @@ imageSource = Sitegeist.Kaleidoscope:DummyImageSource
 renderer = afx`
     <Sitegeist.Kaleidoscope:Picture imageSource={props.imageSource} >
         <Sitegeist.Kaleidoscope:Source 
+            format="webp"
+            srcset='320w, 480w, 800w'
+            sizes='(max-width: 320px) 280px, (max-width: 480px) 440px, 100vw' 
+            />
+        <Sitegeist.Kaleidoscope:Source 
             srcset="1x, 1.5x, 2x" 
             media="screen and (min-width: 1600px)"
             />
@@ -160,11 +165,6 @@ renderer = afx`
             srcset="320w, 480w, 800w"
             sizes="(max-width: 320px) 280px, (max-width: 480px) 440px, 100vw"
             media="screen and (max-width: 1599px)"
-            />
-        <Sitegeist.Kaleidoscope:Source 
-            format="webp"
-            srcset='320w, 480w, 800w'
-            sizes='(max-width: 320px) 280px, (max-width: 480px) 440px, 100vw' 
             />
         <Sitegeist.Kaleidoscope:Source 
             imageSource={props.alternatePintImage} 

--- a/README.md
+++ b/README.md
@@ -163,8 +163,8 @@ renderer = afx`
             />
         <Sitegeist.Kaleidoscope:Source 
             format="webp"
-            srcset = '320w, 480w, 800w'
-            sizes = '(max-width: 320px) 280px, (max-width: 480px) 440px, 100vw' 
+            srcset='320w, 480w, 800w'
+            sizes='(max-width: 320px) 280px, (max-width: 480px) 440px, 100vw' 
             />
         <Sitegeist.Kaleidoscope:Source 
             imageSource={props.alternatePintImage} 


### PR DESCRIPTION
The README.md has a small typo in the "Picture with multiple sources:" example. This can result in a "Prop-assignment was not followed by quotes or braces" error if some one do copy/paste.

And i moved the webp example to top. Because of browsers reading order from top to down and using the first match. 