### PR TITLE
FEATURE: Generic alt and title support

### DIFF
--- a/Classes/EelHelpers/AbstractImageSourceHelper.php
+++ b/Classes/EelHelpers/AbstractImageSourceHelper.php
@@ -54,6 +54,16 @@ abstract class AbstractImageSourceHelper implements ImageSourceHelperInterface
     protected $variantPresets;
 
     /**
+     * @var string|null
+     */
+    protected $title;
+
+    /**
+     * @var string|null
+     */
+    protected $alt;
+
+    /**
      * @param int  $targetWidth
      * @param bool $preserveAspect
      *
@@ -210,6 +220,32 @@ abstract class AbstractImageSourceHelper implements ImageSourceHelperInterface
     }
 
     /**
+     * @param string|null $title
+     */
+    public function setTitle(?string $title): void
+    {
+        $this->title = $title;
+    }
+
+    /**
+     * @param string|null $alt
+     */
+    public function setAlt(?string $alt): void
+    {
+        $this->alt = $alt;
+    }
+
+    public function title(): ?string
+    {
+        return $this->title;
+    }
+
+    public function alt(): ?string
+    {
+        return $this->alt;
+    }
+
+    /**
      * Define which methods are available in the Eel context.
      *
      * @param string $methodName
@@ -218,7 +254,7 @@ abstract class AbstractImageSourceHelper implements ImageSourceHelperInterface
      */
     public function allowsCallOfMethod($methodName)
     {
-        if (in_array($methodName, ['setWidth', 'setHeight', 'setDimensions', 'setFormat', 'applyPreset', 'applyThumbnailPreset', 'useVariantPreset', 'src', 'srcset'])) {
+        if (in_array($methodName, ['setWidth', 'setHeight', 'setDimensions', 'setFormat', 'applyPreset', 'applyThumbnailPreset', 'useVariantPreset', 'src', 'srcset', 'title', 'alt'])) {
             return true;
         }
 

--- a/Classes/EelHelpers/ImageSourceHelperInterface.php
+++ b/Classes/EelHelpers/ImageSourceHelperInterface.php
@@ -33,5 +33,9 @@ interface ImageSourceHelperInterface extends ProtectedContextAwareInterface
 
     public function srcset(string $mediaDescriptors): string;
 
+    public function title(): ?string;
+
+    public function alt(): ?string;
+
     public function __toString(): string;
 }

--- a/Classes/FusionObjects/AbstractImageSourceImplementation.php
+++ b/Classes/FusionObjects/AbstractImageSourceImplementation.php
@@ -50,6 +50,22 @@ abstract class AbstractImageSourceImplementation extends AbstractFusionObject
     }
 
     /**
+     * @return string|null
+     */
+    public function getTitle(): ?string
+    {
+        return $this->fusionValue('title');
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getAlt(): ?string
+    {
+        return $this->fusionValue('alt');
+    }
+
+    /**
      * Create helper and initialize width and height.
      *
      * @return ImageSourceHelperInterface|null

--- a/Classes/FusionObjects/AssetImageSourceImplementation.php
+++ b/Classes/FusionObjects/AssetImageSourceImplementation.php
@@ -58,7 +58,15 @@ class AssetImageSourceImplementation extends AbstractImageSourceImplementation
         if (in_array($asset->getResource()->getMediaType(), $this->nonScalableMediaTypes, true)) {
             $uri = $this->resourceManager->getPublicPersistentResourceUri($asset->getResource());
             if (is_string($uri)) {
-                return new UriImageSourceHelper($uri);
+                $helper = new UriImageSourceHelper($uri);
+                if ($title = $this->getTitle()) {
+                    $helper->setTitle($title);
+                }
+                if ($alt = $this->getAlt()) {
+                    $helper->setAlt($alt);
+                }
+
+                return $helper;
             } else {
                 return null;
             }
@@ -67,6 +75,14 @@ class AssetImageSourceImplementation extends AbstractImageSourceImplementation
         $helper = new AssetImageSourceHelper($asset);
         $helper->setAsync((bool) $this->getAsync());
         $helper->setRequest($this->getRuntime()->getControllerContext()->getRequest());
+
+        if ($title = $this->getTitle()) {
+            $helper->setTitle($title);
+        }
+
+        if ($alt = $this->getAlt()) {
+            $helper->setAlt($alt);
+        }
 
         return $helper;
     }

--- a/Classes/FusionObjects/DummyImageSourceImplementation.php
+++ b/Classes/FusionObjects/DummyImageSourceImplementation.php
@@ -84,6 +84,14 @@ class DummyImageSourceImplementation extends AbstractImageSourceImplementation
             $helper->setText($text);
         }
 
+        if ($title = $this->getTitle()) {
+            $helper->setTitle($title);
+        }
+
+        if ($alt = $this->getAlt()) {
+            $helper->setAlt($alt);
+        }
+
         return $helper;
     }
 }

--- a/Classes/FusionObjects/ResourceImageSourceImplementation.php
+++ b/Classes/FusionObjects/ResourceImageSourceImplementation.php
@@ -27,12 +27,42 @@ class ResourceImageSourceImplementation extends AbstractFusionObject
     }
 
     /**
+     * @return string|null
+     */
+    public function getTitle(): ?string
+    {
+        return $this->fusionValue('title');
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getAlt(): ?string
+    {
+        return $this->fusionValue('alt');
+    }
+
+    /**
      * Create helper and initialize with the default values.
      *
-     * @return ImageSourceHelperInterface
+     * @return ImageSourceHelperInterface|null
      */
-    public function evaluate(): ImageSourceHelperInterface
+    public function evaluate(): ?ImageSourceHelperInterface
     {
-        return new ResourceImageSourceHelper($this->getPackage(), $this->getPath());
+        if ($path = $this->getPath()) {
+            $helper = new ResourceImageSourceHelper($this->getPackage(), $path);
+        } else {
+            return null;
+        }
+
+        if ($title = $this->getTitle()) {
+            $helper->setTitle($title);
+        }
+
+        if ($alt = $this->getAlt()) {
+            $helper->setAlt($alt);
+        }
+
+        return $helper;
     }
 }

--- a/Classes/FusionObjects/UriImageSourceImplementation.php
+++ b/Classes/FusionObjects/UriImageSourceImplementation.php
@@ -19,12 +19,42 @@ class UriImageSourceImplementation extends AbstractFusionObject
     }
 
     /**
+     * @return string|null
+     */
+    public function getTitle(): ?string
+    {
+        return $this->fusionValue('title');
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getAlt(): ?string
+    {
+        return $this->fusionValue('alt');
+    }
+
+    /**
      * Create helper and initialize with the default values.
      *
-     * @return ImageSourceHelperInterface
+     * @return ImageSourceHelperInterface|null
      */
-    public function evaluate(): ImageSourceHelperInterface
+    public function evaluate(): ?ImageSourceHelperInterface
     {
-        return new UriImageSourceHelper($this->getUri());
+        if ($uri = $this->getUri()) {
+            $helper = new UriImageSourceHelper($uri);
+        } else {
+            return null;
+        }
+
+        if ($title = $this->getTitle()) {
+            $helper->setTitle($title);
+        }
+
+        if ($alt = $this->getAlt()) {
+            $helper->setAlt($alt);
+        }
+
+        return $helper;
     }
 }

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Props:
 - `format`: (optional) the image-format like `webp` or `png`, will be applied to the `imageSource`
 - `width`: (optional) the base width, will be applied to the `imageSource`    
 - `height`: (optional) the base height, will be applied to the `imageSource`    
-- `alt`: alt-attribute for the img tag
+- `alt`: alt-attribute for the img tag (default "")
 - `title`: title attribute for the img tag
 - `class`: class attribute for the img tag
 - `renderDimensionAttributes`: render dimension attributes (width/height) when the data is available from the imageSource. Enabled by default
@@ -245,6 +245,8 @@ via fusion but can also applied on the returned object. This will override the f
 
 All ImageSources support the following fusion properties:
 
+- `alt`: The alt attribute if not specified otherwise (default null)
+- `title`: The title attribute if not specified otherwise (default null)
 - `thumbnailPreset`: Set width and/or height via named thumbnail preset from Settings `Neos.Media.thumbnailPresets` (default null, settings below override the preset)
 - `variantPreset`: Select image variant via named variant preset, given as `IDENTIFIER::VARIANTNAME` keys from Settings `Neos.Media.variantPresets` (default null, settings below override the preset)
 - `width`: Set the intended width (default null)

--- a/Resources/Private/Fusion/Prototypes/Image.fusion
+++ b/Resources/Private/Fusion/Prototypes/Image.fusion
@@ -3,10 +3,37 @@ prototype(Sitegeist.Kaleidoscope:Image) < prototype(Neos.Fusion:Component) {
     @styleguide {
         props {
             imageSource = Sitegeist.Kaleidoscope:DummyImageSource
-            alt = 'Elva dressed as a fairy'
         }
 
         propSets {
+            altAndTitleFromSource {
+                imageSource = Sitegeist.Kaleidoscope:DummyImageSource {
+                    alt = 'Alternate assigned to source'
+                    title = 'Title assigned to source'
+                }
+            }
+
+            overrideAltAndTitleFromProp {
+                alt = 'Alternate assigned as prop'
+                title = 'Title assigned as prop'
+            }
+
+            withResourceImageSource {
+                imageSource = Sitegeist.Kaleidoscope:ResourceImageSource {
+                    path = "resource://Sitegeist.Kaleidoscope/Public/Images/imageError.png"
+                    alt = 'Alternate assigned to source'
+                    title = 'Title assigned to source'
+                }
+            }
+
+            withUriImageSource {
+                imageSource = Sitegeist.Kaleidoscope:UriImageSource {
+                    uri = "https://dummyimage.com/600x400/000/fff"
+                    alt = 'Alternate assigned to source'
+                    title = 'Title assigned to source'
+                }
+            }
+
             multires_array {
                 srcset = ${['1x', '1.5x', '2x']}
             }
@@ -42,7 +69,7 @@ prototype(Sitegeist.Kaleidoscope:Image) < prototype(Neos.Fusion:Component) {
     imageSource = null
     srcset = null
     sizes = null
-    alt = ''
+    alt = null
     title = null
     class = null
     loading = null
@@ -77,8 +104,8 @@ prototype(Sitegeist.Kaleidoscope:Image) < prototype(Neos.Fusion:Component) {
                 sizes.@process.join={Type.isArray(value) ? Array.join(value, ', ') : value}
                 loading={props.loading}
                 class={props.class}
-                alt={props.alt}
-                title={props.title}
+                alt={props.alt || props.imageSource.alt() || ''}
+                title={props.title || props.imageSource.title()}
                 width={props.renderDimensionAttributes ? props.imageSource.currentWidth : null}
                 height={props.renderDimensionAttributes ? props.imageSource.currentHeight : null}
             />


### PR DESCRIPTION
All imageSource FusionObjects now support the fusion attributes 'alt' and 'title' that will be used as fallback for the
respective attributes of the img-tag. That way it is no longer necessary to pass three separate properties around.

Examples:

1. Use title and alternativeText from node properties with fallback to the asset title:
```
imageSource = Sitegeist.Kaleidoscope:AssetImageSource {
    asset = ${q(node).property('image')}
    title =  ${q(node).property('title') || q(node).property('image').title}
    alt = ${q(node).property('alternativeText')}
}
```

2. Set alt and title for dummy image source
```
imageSource = Sitegeist.Kaleidoscope:DummyImageSource {
    alt = 'Alternate assigned to source'
    title = 'Title assigned to source'
}
```