### PR TITLE
BUGFIX: Remove src attributes from source tag that is technically allowed but ignored inside of picture elements

### DIFF
--- a/Resources/Private/Fusion/Prototypes/Source.fusion
+++ b/Resources/Private/Fusion/Prototypes/Source.fusion
@@ -38,7 +38,6 @@ prototype(Sitegeist.Kaleidoscope:Source) < prototype(Neos.Fusion:Component) {
 
         renderer = afx`
             <source @if.has={props.imageSource}
-                src={props.imageSource.src()}
                 srcset={props.imageSource.srcset(props.srcset)}
                 srcset.@if.has={props.srcset}
                 sizes={props.sizes}


### PR DESCRIPTION
see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/source