### PR TITLE
BUGFIX: Fallback to Imagick and to gif instead of webp

### DIFF
--- a/Classes/Controller/DummyImageController.php
+++ b/Classes/Controller/DummyImageController.php
@@ -6,7 +6,6 @@ namespace Sitegeist\Kaleidoscope\Controller;
 
 use Imagine\Image\Box;
 use Imagine\Image\ImageInterface;
-use Imagine\Image\ImagineInterface;
 use Imagine\Image\Palette;
 use Imagine\Image\Palette\Color\ColorInterface;
 use Imagine\Image\Point;
@@ -21,7 +20,6 @@ use Psr\Log\LoggerInterface;
 class DummyImageController extends ActionController
 {
     /**
-     * @var ImagineInterface
      * @Flow\Inject
      */
     protected $imagineService;
@@ -45,6 +43,16 @@ class DummyImageController extends ActionController
      */
     protected $logger;
 
+    /*
+     * Override the default Imagine driver from Neos.Imagine
+     * with a static Imagick instance,
+     * because Vips does not yet support draw
+     */
+    public function initializeObject()
+    {
+        $this->imagineService = new \Imagine\Imagick\Imagine();
+    }
+
     /**
      * Get a dummy-image.
      *
@@ -59,6 +67,11 @@ class DummyImageController extends ActionController
      */
     public function imageAction(int $w = 600, int $h = 400, string $bg = '#000', string $fg = '#fff', string $t = null, string $f = 'png'): string
     {
+        // Fallback to gif, because webp is not supported
+        if ($f === 'webp') {
+            $f = 'gif';
+        }
+
         // limit input arguments
         if ($w > 9999) {
             $w = 9999;


### PR DESCRIPTION
Bugfix for issue #37 

Approach: we now always use the Imagick driver, independent of the selected driver, because Vips does not support draw at all and then the DummyImageController would be pointless. Moreover, if webp is requested, we switch to gif as there is no support for webp yet.

Shortcomings: Imagick might not be available either