### PR TITLE
FEATURE: Render width and height for Picture Sources to prevent layout shifts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,8 @@ Props:
 - `height`: (optional) the base height, will be applied to the `imageSource`    
 - `type`: (optional) the type attribute for the source like `image/png` or `image/webp`, the actual format is enforced via `imageSource.setFormat()`
 - `media`: (optional) the media query for the given source
+- `renderDimensionAttributes`: render dimension attributes (width/height) for the source-tag when the data is available from the imageSource
+  if not specified renderDimensionAttributes will be enabled automatically.
 
 ## Responsive Images with AtomicFusion-Components and Sitegeist.Monocle
 

--- a/Resources/Private/Fusion/Prototypes/Picture.fusion
+++ b/Resources/Private/Fusion/Prototypes/Picture.fusion
@@ -24,6 +24,12 @@ prototype(Sitegeist.Kaleidoscope:Picture) < prototype(Neos.Fusion:Component) {
                     }
                     media = 'print'
                 }
+                4 = Neos.Fusion:RawArray {
+                    srcset = '400w, 800w, 1600w'
+                    media = 'screen and (min-width: 2600px)'
+                    width = 800
+                    height = 300
+                }
             }
             alt = 'Elva dressed as a fairy'
         }
@@ -41,7 +47,7 @@ prototype(Sitegeist.Kaleidoscope:Picture) < prototype(Neos.Fusion:Component) {
     title = null
     class = null
     content = ''
-    renderDimensionAttributes = null
+    renderDimensionAttributes = true
 
     #
     # put the values that shall be applied to sources automatically to the context
@@ -74,7 +80,7 @@ prototype(Sitegeist.Kaleidoscope:Picture) < prototype(Neos.Fusion:Component) {
         title = ${props.title}
         class = ${props.class}
         content = ${props.content}
-        renderDimensionAttributes = ${Type.isBoolean(props.renderDimensionAttributes) ? props.renderDimensionAttributes : (!props.content && !props.sources)}
+        renderDimensionAttributes = ${props.renderDimensionAttributes}
 
         renderer = afx`
             <picture class={props.class}>
@@ -89,6 +95,7 @@ prototype(Sitegeist.Kaleidoscope:Picture) < prototype(Neos.Fusion:Component) {
                         height={source.height}
                         srcset={source.srcset ? source.srcset : props.srcset}
                         sizes={source.sizes ? source.sizes : props.sizes}
+                        renderDimensionAttributes={props.renderDimensionAttributes}
                     />
                 </Neos.Fusion:Collection>
                 <Neos.Fusion:Collection

--- a/Resources/Private/Fusion/Prototypes/Source.fusion
+++ b/Resources/Private/Fusion/Prototypes/Source.fusion
@@ -12,6 +12,7 @@ prototype(Sitegeist.Kaleidoscope:Source) < prototype(Neos.Fusion:Component) {
     format = null
     type = null
     media = null
+    renderDimensionAttributes = true
 
     renderer = Neos.Fusion:Component {
 
@@ -35,6 +36,7 @@ prototype(Sitegeist.Kaleidoscope:Source) < prototype(Neos.Fusion:Component) {
         srcset = ${srcset}
         sizes = ${sizes}
         media = ${props.media}
+        renderDimensionAttributes = ${props.renderDimensionAttributes}
 
         renderer = afx`
             <source @if.has={props.imageSource}
@@ -44,6 +46,8 @@ prototype(Sitegeist.Kaleidoscope:Source) < prototype(Neos.Fusion:Component) {
                 sizes.@process.join={Type.isArray(value) ? Array.join(value, ', ') : value}
                 type={props.type}
                 media={props.media}
+                width={props.renderDimensionAttributes ? props.imageSource.currentWidth : null}
+                height={props.renderDimensionAttributes ? props.imageSource.currentHeight : null}
             />
         `
     }


### PR DESCRIPTION
This is controlled by the property. renderDimensionAttributes which is enabled by default.