### PR TITLE
BUGFIX: Apply `width` and `height` for `Sitegeist.Kaleidoscope:Picture` with `formats`

### DIFF
--- a/Resources/Private/Fusion/Prototypes/Picture.fusion
+++ b/Resources/Private/Fusion/Prototypes/Picture.fusion
@@ -121,7 +121,10 @@ prototype(Sitegeist.Kaleidoscope:Picture) < prototype(Neos.Fusion:Component) {
                     collection={Type.isArray(props.formats) ? props.formats : String.split(props.formats, ',')}
                     itemName="format"
                 >
-                    <Sitegeist.Kaleidoscope:Source format={String.trim(format)} />
+                    <Sitegeist.Kaleidoscope:Source
+                        imageSource={props.imageSource}
+                        format={String.trim(format)}
+                    />
                 </Neos.Fusion:Collection>
                 <Sitegeist.Kaleidoscope:Image
                     imageSource={props.imageSource}


### PR DESCRIPTION
Apply width and height constraints defined for the main element to the items when the formats option is used to render multiple formats in Sitegeist.Kaleidoscope:Picture