### PR TITLE
BUGFIX: Respect aspect ratio

### DIFF
--- a/Classes/Domain/AbstractScalableImageSource.php
+++ b/Classes/Domain/AbstractScalableImageSource.php
@@ -44,7 +44,11 @@ abstract class AbstractScalableImageSource extends AbstractImageSource implement
         $newSource = clone $this;
         $newSource->targetWidth = $targetWidth;
         if ($preserveAspect === true) {
-            $aspect = ($this->targetWidth ?: $this->baseWidth) / ($this->targetHeight ?: $this->baseHeight);
+            if ($this->targetWidth && $this->targetHeight) {
+                $aspect = $this->targetWidth / $this->targetHeight;
+            } else {
+                $aspect = $this->baseWidth / $this->baseHeight;
+            }
             $newSource->targetHeight = (int) round($targetWidth / $aspect);
         }
 
@@ -62,7 +66,11 @@ abstract class AbstractScalableImageSource extends AbstractImageSource implement
         $newSource = clone $this;
         $newSource->targetHeight = $targetHeight;
         if ($preserveAspect === true) {
-            $aspect = ($this->targetWidth ?: $this->baseWidth) / ($this->targetHeight ?: $this->baseHeight);
+            if ($this->targetWidth && $this->targetHeight) {
+                $aspect = $this->targetWidth / $this->targetHeight;
+            } else {
+                $aspect = $this->baseWidth / $this->baseHeight;
+            }
             $newSource->targetWidth = (int) round($targetHeight * $aspect);
         }
 


### PR DESCRIPTION
Use targetWidth and targetHeight for aspect ratio calculation when both are set. Otherwise this leads to unwanted results. We observed this behaviour with `srcset` and `1x, 2x` and `imageSource.withHeight(40, true)`