### PR TITLE
BUGFIX: Output srcset in Source.fusion

### DIFF
--- a/Resources/Private/Fusion/Prototypes/Source.fusion
+++ b/Resources/Private/Fusion/Prototypes/Source.fusion
@@ -42,9 +42,8 @@ prototype(Sitegeist.Kaleidoscope:Source) < prototype(Neos.Fusion:Component) {
         renderer = afx`
             <source @if.has={props.imageSource}
                 srcset={props.imageSource.srcset(props.srcset)}
-                srcset.@if.isScalable={props.srcset && props.isScalableSource}
                 sizes={props.sizes}
-                srcset.@if.isScalable={props.sizes && props.isScalableSource}
+                sizes.@if.isScalable={props.sizes && props.isScalableSource}
                 sizes.@process.join={Type.isArray(value) ? Array.join(value, ', ') : value}
                 type={props.type}
                 media={props.media}


### PR DESCRIPTION
This fixes non-scalable images with different type sources. Currently, these images sources are empty.

Fixes #68 