### PR TITLE
TASK: Make BaseUri argument nullable in DummyImageSource constructor

### DIFF
--- a/Classes/Domain/DummyImageSource.php
+++ b/Classes/Domain/DummyImageSource.php
@@ -5,6 +5,12 @@ declare(strict_types=1);
 namespace Sitegeist\Kaleidoscope\Domain;
 
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Http\ServerRequestAttributes;
+use Neos\Flow\Mvc\ActionRequestFactory;
+use Neos\Flow\Mvc\Routing\Dto\RouteParameters;
+use Neos\Flow\Mvc\Routing\UriBuilder;
+use Psr\Http\Message\ServerRequestFactoryInterface;
+use Psr\Http\Message\UriFactoryInterface;
 
 class DummyImageSource extends AbstractScalableImageSource
 {
@@ -14,6 +20,24 @@ class DummyImageSource extends AbstractScalableImageSource
      * @Flow\Inject
      */
     protected $dummyImageGenerator;
+
+    /**
+     * @var UriFactoryInterface
+     * @Flow\Inject
+     */
+    protected $uriFactory;
+
+    /**
+     * @var ServerRequestFactoryInterface
+     * @Flow\Inject
+     */
+    protected $serverRequestFactory;
+
+    /**
+     * @var ActionRequestFactory
+     * @Flow\Inject
+     */
+    protected $actionRequestFactory;
 
     /**
      * @var string
@@ -31,12 +55,12 @@ class DummyImageSource extends AbstractScalableImageSource
     protected $text;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $baseUri;
 
     /**
-     * @param string      $baseUri
+     * @param string|null $baseUri
      * @param string|null $title
      * @param string|null $alt
      * @param int|null    $baseWidth
@@ -45,7 +69,7 @@ class DummyImageSource extends AbstractScalableImageSource
      * @param string|null $foregroundColor
      * @param string|null $text
      */
-    public function __construct(string $baseUri, ?string $title = null, ?string $alt = null, ?int $baseWidth = null, ?int $baseHeight = null, ?string $backgroundColor = null, ?string $foregroundColor = null, ?string $text = null)
+    public function __construct(?string $baseUri, ?string $title = null, ?string $alt = null, ?int $baseWidth = null, ?int $baseHeight = null, ?string $backgroundColor = null, ?string $foregroundColor = null, ?string $text = null)
     {
         parent::__construct($title, $alt);
         $this->baseUri = $baseUri;
@@ -83,6 +107,25 @@ class DummyImageSource extends AbstractScalableImageSource
      */
     public function src(): string
     {
+        if (is_string($this->baseUri)) {
+            $baseUri = $this->baseUri;
+        } else {
+            $uri = $this->uriFactory->createUri('http://localhost');
+
+            $httpRequest = $this->serverRequestFactory->createServerRequest('GET', $uri)
+                ->withAttribute(
+                    ServerRequestAttributes::ROUTING_PARAMETERS,
+                    RouteParameters::createEmpty()->withParameter('requestUriHost', $uri->getHost())
+                );
+
+            $uriBuilder = new UriBuilder();
+            $uriBuilder->setRequest($this->actionRequestFactory->createActionRequest($httpRequest));
+            $uriBuilder->setFormat('html');
+            $uriBuilder->setCreateAbsoluteUri(false);
+
+            $baseUri = $uriBuilder->uriFor('image', [], 'DummyImage', 'Sitegeist.Kaleidoscope');
+        }
+
         $arguments = [
             'w' => $this->getCurrentWidth(),
             'h' => $this->getCurrentHeight(),
@@ -104,7 +147,7 @@ class DummyImageSource extends AbstractScalableImageSource
             $arguments['f'] = $this->targetFormat;
         }
 
-        return $this->baseUri . '?' . http_build_query($arguments);
+        return $baseUri . '?' . http_build_query($arguments);
     }
 
     public function dataSrc(): string


### PR DESCRIPTION
The base uri is for the dummy image controller is created internally if not given from the outside.

This makes creating those image sources programmatically much easier.