### PR TITLE
BUGFIX: Build correct dummy image urls again

### DIFF
--- a/Classes/Domain/DummyImageSource.php
+++ b/Classes/Domain/DummyImageSource.php
@@ -132,7 +132,6 @@ class DummyImageSource extends AbstractScalableImageSource
 
             $uriBuilder = new UriBuilder();
             $uriBuilder->setRequest($this->actionRequestFactory->createActionRequest($httpRequest));
-            $uriBuilder->setFormat('html');
             $uriBuilder->setCreateAbsoluteUri(false);
 
             $baseUri = $uriBuilder->uriFor('image', [], 'DummyImage', 'Sitegeist.Kaleidoscope');


### PR DESCRIPTION
Dummy images rendered wrong urls that prevented the url-parameters from beeing interpreted correctly.