### PR TITLE
BUGFIX: Remove obsolete `imagineService` in Configuration/Objects.yaml

### DIFF
--- a/Configuration/Objects.yaml
+++ b/Configuration/Objects.yaml
@@ -1,5 +1,0 @@
-Sitegeist\Kaleidoscope\Controller\DummyImageController:
-  properties:
-    imagineService:
-      object:
-        factoryObjectName: Neos\Imagine\ImagineFactory


### PR DESCRIPTION
Solves https://github.com/sitegeist/Sitegeist.Kaleidoscope/issues/88

Didnt look into the history asto why there was the config in the first place - but it seems to work without?